### PR TITLE
Update twitter reference to be secure.

### DIFF
--- a/angular-social.src.js
+++ b/angular-social.src.js
@@ -17,7 +17,7 @@ app.directive('ngSocialButtons', ['$compile', '$q', '$parse', '$http', '$locatio
             restrict: 'A',
             scope: {
                 'url': '=',
-                'title': '=',
+                'title': '=',
                 'description': '=',
                 'image': '=',
                 'showcounts': '='
@@ -175,7 +175,7 @@ app.directive('ngSocialTwitter', function() {
             }
         },
         popup: {
-            url: 'http://twitter.com/intent/tweet?url={url}&text={title}',
+            url: 'https://twitter.com/intent/tweet?url={url}&text={title}',
             width: 600,
             height: 450
         },


### PR DESCRIPTION
The insecure link is currently just redirected to the secure link by twitter. This update goes directly to the secure version that people will end up at anyway.

Below is a capture of the insecure version being redirected to the secure version by Twitter:

```
$ HEAD -sSe 'http://twitter.com/intent/tweet'
HEAD http://twitter.com/intent/tweet
301 Moved Permanently
Date: Thu, 26 Dec 2013 20:48:23 UTC
Location: https://twitter.com/intent/tweet
Server: tfe
Content-Length: 0
Client-Date: Thu, 26 Dec 2013 20:48:22 GMT
Client-Peer: 199.59.149.198:80
Client-Response-Num: 1
Set-Cookie: guest_id=v1%3A138809090301612382; Domain=.twitter.com; Path=/; Expires=Sat, 26-Dec-2015 20:48:23 UTC

HEAD https://twitter.com/intent/tweet
200 OK
```
