### PR TITLE
Fix for Issue #12

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -5,6 +5,6 @@
   "ignore": [
   ],
   "dependencies": {
-    "angular": "~1.0.6"
+    "angular": ">= 1.0.6"
   }
 }


### PR DESCRIPTION
Specifying Angular 1.0.6 or above as the dependency so that you don't get a conflict when you're using a different version of Angular and using bower to install angular-social.
